### PR TITLE
Overrode minimap coordinates and made warpspace void.

### DIFF
--- a/src/me/iron/WarpSpace/Mod/WarpMain.java
+++ b/src/me/iron/WarpSpace/Mod/WarpMain.java
@@ -2,7 +2,6 @@ package me.iron.WarpSpace.Mod;
 
 import api.listener.events.controller.ClientInitializeEvent;
 import api.listener.events.controller.ServerInitializeEvent;
-import api.listener.events.world.sector.SegmentControllerUnloadEvent;
 import api.mod.StarMod;
 import api.network.packets.PacketUtil;
 import me.iron.WarpSpace.Mod.HUD.client.*;
@@ -12,7 +11,7 @@ import me.iron.WarpSpace.Mod.server.WarpCheckLoop;
 import me.iron.WarpSpace.Mod.server.WarpJumpEventHandler;
 import me.iron.WarpSpace.Mod.server.WarpJumpListener;
 import me.iron.WarpSpace.Mod.network.PacketSCUpdateWarp;
-import org.schema.game.common.controller.SegmentController;
+import me.iron.WarpSpace.Mod.taswin.WarpSpaceMap;
 
 /**
  * STARMADE MOD
@@ -37,8 +36,15 @@ public class WarpMain extends StarMod {
         instance = this;
         PacketUtil.registerPacket(PacketSCUpdateWarp.class);
         PacketUtil.registerPacket(PacketHUDUpdate.class);
+        
+        WarpSpaceMap.enable(instance);
     }
-
+    
+    @Override
+    public void onDisable() {
+        WarpSpaceMap.disable();
+    }
+    
     @Override
     public void onServerCreated(ServerInitializeEvent event) {
         super.onServerCreated(event);

--- a/src/me/iron/WarpSpace/Mod/WarpManager.java
+++ b/src/me/iron/WarpSpace/Mod/WarpManager.java
@@ -8,7 +8,9 @@ package me.iron.WarpSpace.Mod;
  */
 
 import org.schema.common.util.linAlg.Vector3i;
+import org.schema.game.client.view.gamemap.GameMapDrawer;
 import org.schema.game.common.controller.SegmentController;
+import org.schema.game.server.data.Galaxy;
 
 import javax.vecmath.Vector3f;
 
@@ -24,7 +26,7 @@ public class WarpManager {
     /**
      * the offset of warpspace to the realspace sector on the y axis. Use a number outside of the galaxy: empty space
      */
-    public static int offset = 150; //offset in sectors
+    public static int offset = (int)(Galaxy.size * 16 * 2 * (1 + 1f / scale)); //offset in sectors
 
     /**
      *  minimum speed required to stay in warp
@@ -46,7 +48,7 @@ public class WarpManager {
      * @return boolean, true if position is in warp
      */
     public static boolean IsInWarp(Vector3i pos) {
-        if (pos.y >= offset) {
+        if (pos.y >= offset - (Galaxy.size * 16 * 2 / scale) && pos.y <= offset + (Galaxy.size * 16 * 2 / scale)) {
             return true;
         }
         return false;
@@ -63,26 +65,26 @@ public class WarpManager {
         realPosF.x = Math.round(realPosF.x / scale);
         realPosF.y = Math.round(realPosF.y / scale);
         realPosF.z = Math.round(realPosF.z / scale);
-        realPosF.y += offset * 2; //offset sectors to up (y axis)
+        realPosF.y += offset; //offset sectors to up (y axis)
         warpPos = new Vector3i(realPosF.x,realPosF.y,realPosF.z);
-
+    
         return warpPos;
     }
-
+    
     /**
      * Calculate the realspace position from a warpspace position
      * @param WarpSpacePos sector in warpspace
      * @return correlating sector in realspace
      */
     public static Vector3i GetRealSpacePos(Vector3i WarpSpacePos) {
-        Vector3i warpPos;
-        Vector3f realPosF = WarpSpacePos.toVector3f();
-        realPosF.y -= offset * 2; //offset sectors to up (y axis)
-        realPosF.x = Math.round(realPosF.x * scale);
-        realPosF.y = Math.round(realPosF.y * scale);
-        realPosF.z = Math.round(realPosF.z * scale);
-        warpPos = new Vector3i(realPosF.x,realPosF.y,realPosF.z);
-
-        return warpPos;
+        Vector3i realPos;
+        Vector3f warpPosF = WarpSpacePos.toVector3f();
+        warpPosF.y -= offset; //offset sectors to up (y axis)
+        warpPosF.x = Math.round(warpPosF.x * scale);
+        warpPosF.y = Math.round(warpPosF.y * scale);
+        warpPosF.z = Math.round(warpPosF.z * scale);
+        realPos = new Vector3i(warpPosF.x,warpPosF.y,warpPosF.z);
+    
+        return realPos;
     }
 }

--- a/src/me/iron/WarpSpace/Mod/WarpManager.java
+++ b/src/me/iron/WarpSpace/Mod/WarpManager.java
@@ -22,11 +22,17 @@ public class WarpManager {
      *  the scale of realspace to warpspace in sectors.
      */
     public static int scale = 10; //scale warpspace distance to realspace distance
-
+    
+    /**
+     * Galaxy size * System size * 64 + Galaxy size * System size * 64 / scale + System size * 2
+     * 64 galaxies realspace + 64 galaxies warpspace + 2 systems buffer.
+     */
+    public static int universeSize = Galaxy.size * 16 * 64;
+    
     /**
      * the offset of warpspace to the realspace sector on the y axis. Use a number outside of the galaxy: empty space
      */
-    public static int offset = (int)(Galaxy.size * 16 * 2 * (1 + 1f / scale)); //offset in sectors
+    public static int offset = (int)(universeSize * (1 + 1f / scale)) + 16 * 2; //offset in sectors
 
     /**
      *  minimum speed required to stay in warp
@@ -48,7 +54,7 @@ public class WarpManager {
      * @return boolean, true if position is in warp
      */
     public static boolean IsInWarp(Vector3i pos) {
-        if (pos.y >= offset - (Galaxy.size * 16 * 2 / scale) && pos.y <= offset + (Galaxy.size * 16 * 2 / scale)) {
+        if (pos.y >= offset - (universeSize / scale) && pos.y <= offset + (universeSize / scale)) {
             return true;
         }
         return false;

--- a/src/me/iron/WarpSpace/Mod/taswin/MyGameMapListener.java
+++ b/src/me/iron/WarpSpace/Mod/taswin/MyGameMapListener.java
@@ -94,13 +94,14 @@ public class MyGameMapListener implements GameMapDrawListener
 		if (!WarpManager.IsInWarp(drawer.getPlayerSector())) return;
 		
 		Vector3i realCoords = WarpManager.GetRealSpacePos(drawer.getPlayerSector());
-		realCoords.scaleFloat(1f / (WarpManager.scale * 16));
+		realCoords.scaleFloat(1 / 16f);
 		
-		Vector3i galaxyPos = drawer.getState().getCurrentGalaxy().galaxyPos;
+		Vector3i galaxyPos = new Vector3i(drawer.getState().getCurrentGalaxy().galaxyPos);
 		Galaxy.getContainingGalaxyFromSystemPos(realCoords, galaxyPos);
 		
 		Sprite sprite = Controller.getResLoader().getSprite("stellarSprites-2x2-c-");
 		if (stars == null) return;
+		if (stars.get(galaxyPos) == null) return;
 		for(PositionableSubColorSprite[] sp : stars.get(galaxyPos).values())
 		{
 			DrawUtils.drawSprite(drawer, sprite, sp);

--- a/src/me/iron/WarpSpace/Mod/taswin/MyGameMapListener.java
+++ b/src/me/iron/WarpSpace/Mod/taswin/MyGameMapListener.java
@@ -1,0 +1,129 @@
+package me.iron.WarpSpace.Mod.taswin;
+
+import api.listener.fastevents.GameMapDrawListener;
+import me.iron.WarpSpace.Mod.WarpManager;
+import org.lwjgl.opengl.GL11;
+import org.schema.common.util.linAlg.Vector3i;
+import org.schema.game.client.view.gamemap.GameMapDrawer;
+import org.schema.game.server.data.Galaxy;
+import org.schema.schine.graphicsengine.core.Controller;
+import org.schema.schine.graphicsengine.core.GlUtil;
+import org.schema.schine.graphicsengine.forms.PositionableSubColorSprite;
+import org.schema.schine.graphicsengine.forms.Sprite;
+
+import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
+
+import static me.iron.WarpSpace.Mod.taswin.WarpSpaceMap.stars;
+
+public class MyGameMapListener implements GameMapDrawListener
+{
+	public static void drawCube(Vector3f pos, float size, Vector4f color)
+	{
+		//pos.scale(100 / 16);
+		
+		GlUtil.glBegin(7);
+		GlUtil.glColor4f(color.x, color.y, color.z, color.w);
+		GL11.glNormal3f(0.0F, 0.0F, 1.0F);
+		GL11.glVertex3f(pos.x + size, pos.y + size, pos.z + -size);
+		GL11.glVertex3f(pos.x + size, pos.y + -size, pos.z + -size);
+		GL11.glVertex3f(pos.x + -size, pos.y + -size, pos.z + -size);
+		GL11.glVertex3f(pos.x + -size, pos.y + size, pos.z + -size);
+		GL11.glNormal3f(0.0F, 0.0F, -1.0F);
+		GL11.glVertex3f(pos.x + size, pos.y + -size, pos.z + size);
+		GL11.glVertex3f(pos.x + size, pos.y + size, pos.z + size);
+		GL11.glVertex3f(pos.x + -size, pos.y + size, pos.z + size);
+		GL11.glVertex3f(pos.x + -size, pos.y + -size, pos.z + size);
+		GL11.glNormal3f(-1.0F, 0.0F, 0.0F);
+		GL11.glVertex3f(pos.x + size, pos.y + -size, pos.z + -size);
+		GL11.glVertex3f(pos.x + size, pos.y + size, pos.z + -size);
+		GL11.glVertex3f(pos.x + size, pos.y + size, pos.z + size);
+		GL11.glVertex3f(pos.x + size, pos.y + -size, pos.z + size);
+		GL11.glNormal3f(1.0F, 0.0F, 0.0F);
+		GL11.glVertex3f(pos.x + -size, pos.y + -size, pos.z + size);
+		GL11.glVertex3f(pos.x + -size, pos.y + size, pos.z + size);
+		GL11.glVertex3f(pos.x + -size, pos.y + size, pos.z + -size);
+		GL11.glVertex3f(pos.x + -size, pos.y + -size, pos.z + -size);
+		GL11.glNormal3f(0.0F, -1.0F, 0.0F);
+		GL11.glVertex3f(pos.x + size, pos.y + size, pos.z + size);
+		GL11.glVertex3f(pos.x + size, pos.y + size, pos.z + -size);
+		GL11.glVertex3f(pos.x + -size, pos.y + size, pos.z + -size);
+		GL11.glVertex3f(pos.x + -size, pos.y + size, pos.z + size);
+		GL11.glNormal3f(0.0F, 1.0F, 0.0F);
+		GL11.glVertex3f(pos.x + size, pos.y + -size, pos.z + -size);
+		GL11.glVertex3f(pos.x + size, pos.y + -size, pos.z + size);
+		GL11.glVertex3f(pos.x + -size, pos.y + -size, pos.z + size);
+		GL11.glVertex3f(pos.x + -size, pos.y + -size, pos.z + -size);
+		GlUtil.glEnd();
+		GlUtil.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+	}
+	
+	@Override
+	public void system_PreDraw(GameMapDrawer drawer, Vector3i system, boolean explored)
+	{
+	
+	}
+	
+	@Override
+	public void system_PostDraw(GameMapDrawer drawer, Vector3i system, boolean explored)
+	{
+	
+	}
+	
+	@Override
+	public void galaxy_PreDraw(GameMapDrawer drawer)
+	{
+	
+	}
+	
+	@Override
+	public void galaxy_PostDraw(GameMapDrawer drawer)
+	{
+	
+	}
+	
+	@Override
+	public void galaxy_DrawLines(GameMapDrawer drawer)
+	{
+	
+	}
+	
+	@Override
+	public void galaxy_DrawSprites(GameMapDrawer drawer)
+	{
+		if (!WarpManager.IsInWarp(drawer.getPlayerSector())) return;
+		
+		Vector3i realCoords = WarpManager.GetRealSpacePos(drawer.getPlayerSector());
+		realCoords.scaleFloat(1f / (WarpManager.scale * 16));
+		
+		Vector3i galaxyPos = drawer.getState().getCurrentGalaxy().galaxyPos;
+		Galaxy.getContainingGalaxyFromSystemPos(realCoords, galaxyPos);
+		
+		Sprite sprite = Controller.getResLoader().getSprite("stellarSprites-2x2-c-");
+		if (stars == null) return;
+		for(PositionableSubColorSprite[] sp : stars.get(galaxyPos).values())
+		{
+			DrawUtils.drawSprite(drawer, sprite, sp);
+		}
+	}
+	
+	@Override
+	public void galaxy_DrawQuads(GameMapDrawer drawer)
+	{
+		Vector3i sector = drawer.getPlayerSector();
+		if (WarpManager.IsInWarp(sector))
+		{
+			float r = WarpManager.scale / 2f;
+			
+			Vector3i realPos = WarpManager.GetRealSpacePos(sector);
+			drawCube(new Vector3f(
+				(realPos.x - 8f) * GameMapDrawer.sectorSize,
+				(realPos.y - 8f) * GameMapDrawer.sectorSize,
+				(realPos.z - 8f) * GameMapDrawer.sectorSize), r * GameMapDrawer.sectorSize, new Vector4f(0F,1F,1F, 0.25F));
+			/*drawCube(new Vector3f(
+				(realPos.x - 7.5f) * 100f / 16,
+				(realPos.y - 7.5f) * 100f / 16,
+				(realPos.z - 7.5f) * 100f / 16), 0.5f * 100 / 16, new Vector4f(1F,1F,1F, 1F));*/
+		}
+	}
+}

--- a/src/me/iron/WarpSpace/Mod/taswin/WarpSpaceMap.java
+++ b/src/me/iron/WarpSpace/Mod/taswin/WarpSpaceMap.java
@@ -1,0 +1,109 @@
+package me.iron.WarpSpace.Mod.taswin;
+
+import api.listener.Listener;
+import api.listener.events.world.GalaxyFinishedGeneratingEvent;
+import api.listener.fastevents.FastListenerCommon;
+import api.mod.StarLoader;
+import api.mod.StarMod;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import me.iron.WarpSpace.Mod.WarpManager;
+import org.schema.common.util.linAlg.Vector3i;
+import org.schema.game.client.view.gamemap.GameMapDrawer;
+import org.schema.game.server.data.Galaxy;
+import org.schema.schine.graphicsengine.forms.PositionableSubColorSprite;
+import org.schema.schine.graphicsengine.forms.Sprite;
+
+import javax.vecmath.Vector3f;
+import javax.vecmath.Vector4f;
+import java.util.HashMap;
+
+public class WarpSpaceMap
+{
+	public static HashMap<Vector3i, HashMap<Vector3f, PositionableSubColorSprite[]>> stars = new HashMap<>();
+	
+	private static MyGameMapListener myGameMapListener;
+	
+	public static void disable()
+	{
+		FastListenerCommon.gameMapListeners.remove(myGameMapListener);
+	}
+	
+	public static void enable(StarMod instance)
+	{
+		myGameMapListener = new MyGameMapListener();
+		FastListenerCommon.gameMapListeners.add(myGameMapListener);
+		
+		StarLoader.registerListener(GalaxyFinishedGeneratingEvent.class, new Listener<GalaxyFinishedGeneratingEvent>()
+		{
+			@Override
+			public void onEvent(GalaxyFinishedGeneratingEvent event)
+			{
+				final Galaxy galaxy = event.getGalaxy();
+				
+				final ObjectArrayList<Vector3f> starPoses = new ObjectArrayList<>();
+				galaxy.getPositions(starPoses, new FloatArrayList());
+				
+				for (int i = 0; i < starPoses.size(); i++)
+				{
+					final int finalI = i;
+					PositionableSubColorSprite[] s = new PositionableSubColorSprite[]
+						{
+							new PositionableSubColorSprite()
+							{
+								@Override
+								public Vector4f getColor()
+								{
+									return galaxy.getSunColor(new Vector3i(starPoses.get(finalI)));
+								}
+								
+								@Override
+								public float getScale(long l)
+								{
+									return 0.025f;
+								}
+								
+								@Override
+								public int getSubSprite(Sprite sprite)
+								{
+									return galaxy.getSystemType(new Vector3i(starPoses.get(finalI)));
+								}
+								
+								@Override
+								public boolean canDraw()
+								{
+									return true;
+								}
+								
+								@Override
+								public Vector3f getPos()
+								{
+									Vector3f systemPos = starPoses.get(finalI);
+									
+									Vector3i sectorPos = new Vector3i(
+										(systemPos.x - Galaxy.halfSize) * 16,
+										(systemPos.y - Galaxy.halfSize) * 16,
+										(systemPos.z - Galaxy.halfSize) * 16);
+									Vector3f pos = WarpManager.GetWarpSpacePos(sectorPos).toVector3f();
+									
+									Vector3f loaclOffset = galaxy.getSunPositionOffset(new Vector3i(systemPos), new Vector3i()).toVector3f();
+									loaclOffset.scale(1f / WarpManager.scale);
+									
+									pos.x = (pos.x + loaclOffset.x + (8f / WarpManager.scale) - 8 + 0.5f) * GameMapDrawer.sectorSize;
+									pos.y = (pos.y + loaclOffset.y + (8f / WarpManager.scale) - 8 + 0.5f) * GameMapDrawer.sectorSize;
+									pos.z = (pos.z + loaclOffset.z + (8f / WarpManager.scale) - 8 + 0.5f) * GameMapDrawer.sectorSize;
+									
+									return pos;
+								}
+							}
+						};
+					
+					if (!stars.containsKey(galaxy.galaxyPos))
+						stars.put(galaxy.galaxyPos, new HashMap<Vector3f, PositionableSubColorSprite[]>());
+					stars.get(galaxy.galaxyPos).put(starPoses.get(i), s);
+				}
+			}
+		}, instance);
+	}
+	
+}


### PR DESCRIPTION
Overrode the coordinates displayed under the minimap in warp, shifted warpspace further away from the origin of realspace and made sure all systems in warp are void (asteroids may still be found ... mabye).

Handled nullpointer when you attempt inter galactic travel in warp (in order to display the new galaxies stars you will need to drop out of warp.)